### PR TITLE
Fix Offline Cure

### DIFF
--- a/src/main/java/us/rfsmassacre/Werewolf/Commands/WerewolfAdminCommand.java
+++ b/src/main/java/us/rfsmassacre/Werewolf/Commands/WerewolfAdminCommand.java
@@ -338,7 +338,7 @@ public class WerewolfAdminCommand extends SpigotCommand
 						Werewolf werewolf = werewolves.getWerewolf(player);
 						Clan clan = werewolf.getClan();
 
-						WerewolfCureEvent event = new WerewolfCureEvent(player, CureType.COMMAND);
+						WerewolfCureEvent event = new WerewolfCureEvent(player.getUniqueId(), CureType.COMMAND);
 						if (events != null)
 						{
 							events.callEvent(event);

--- a/src/main/java/us/rfsmassacre/Werewolf/Events/WerewolfCureEvent.java
+++ b/src/main/java/us/rfsmassacre/Werewolf/Events/WerewolfCureEvent.java
@@ -1,9 +1,10 @@
 package us.rfsmassacre.Werewolf.Events;
 
-import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
 
 public class WerewolfCureEvent extends Event implements Cancellable
 {
@@ -27,22 +28,22 @@ public class WerewolfCureEvent extends Event implements Cancellable
 	}
 	
 	//Werewolf Cure Event Data
-	private Player player;
+	private UUID uuid;
 	private CureType type;
 	
 	private boolean cancel;
 	
-	public WerewolfCureEvent(Player player, CureType type)
+	public WerewolfCureEvent(UUID uuid, CureType type)
 	{
-		this.player = player;
+		this.uuid = uuid;
 		this.type = type;
 		
 		this.cancel = false;
 	}
 	
-	public Player getPlayer()
+	public UUID getUUID()
 	{
-		return player;
+		return uuid;
 	}
 	public CureType getType()
 	{

--- a/src/main/java/us/rfsmassacre/Werewolf/Listeners/WerewolfInfectionListener.java
+++ b/src/main/java/us/rfsmassacre/Werewolf/Listeners/WerewolfInfectionListener.java
@@ -2,6 +2,7 @@ package us.rfsmassacre.Werewolf.Listeners;
 
 import java.util.Random;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Wolf;
@@ -186,7 +187,7 @@ public class WerewolfInfectionListener implements Listener
 			CureType type = CureType.CURE_POTION;
 			Clan clan = werewolf.getClan();
 			
-			WerewolfCureEvent cureEvent = new WerewolfCureEvent(player, type);
+			WerewolfCureEvent cureEvent = new WerewolfCureEvent(player.getUniqueId(), type);
 			events.callEvent(cureEvent);
 			if (!cureEvent.isCancelled())
 			{
@@ -240,6 +241,8 @@ public class WerewolfInfectionListener implements Listener
 	@EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
 	public void onWerewolfGroupRemove(WerewolfCureEvent event)
 	{
-		WerewolfPlugin.setGroup(event.getPlayer(), false);
+		Player player = Bukkit.getPlayer(event.getUUID());
+		
+		if (player != null) WerewolfPlugin.setGroup(player, false);
 	}
 }

--- a/src/main/java/us/rfsmassacre/Werewolf/Managers/WerewolfManager.java
+++ b/src/main/java/us/rfsmassacre/Werewolf/Managers/WerewolfManager.java
@@ -257,7 +257,7 @@ public class WerewolfManager
         			long cureDelay = config.getLong("auto-cure.days") * MILLIS_IN_DAY;
         			if (noCureTime >= cureDelay)
         			{
-        				WerewolfCureEvent cureEvent = new WerewolfCureEvent(werewolf.getPlayer(), CureType.AUTO_CURE);
+        				WerewolfCureEvent cureEvent = new WerewolfCureEvent(werewolf.getUUID(), CureType.AUTO_CURE);
         				if (events != null)
         					events.callEvent(cureEvent);
         				if (!cureEvent.isCancelled())


### PR DESCRIPTION
Fix the NPE that is thrown because the Player object required for the cure event is null.
- Changed the event to use UUID instead because working with a null player in an event was not as useful.
- Added a check to ensure that the player is online for the group permission to be updated as there is already a check to change groups on join.

###### Sadly not able to build and test the changes due to my AV deleting the dependencies as it thinks they are trojans